### PR TITLE
Fix jumps issue at the end of pan gesture

### DIFF
--- a/src/components/crop/CropZoom.tsx
+++ b/src/components/crop/CropZoom.tsx
@@ -164,7 +164,6 @@ const CropZoom: React.FC<CropZoomProps> = (props) => {
   });
 
   const pinch = Gesture.Pinch()
-    .enabled(gesturesEnabled)
     .onStart(onPinchStart)
     .onUpdate(onPinchUpdate)
     .onEnd(onPinchEnd);

--- a/src/components/crop/CropZoom.tsx
+++ b/src/components/crop/CropZoom.tsx
@@ -1,5 +1,5 @@
 import React, { useImperativeHandle } from 'react';
-import { StyleSheet, View, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, View, type ViewStyle } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useDerivedValue,
@@ -42,7 +42,7 @@ const CropZoom: React.FC<CropZoomProps> = (props) => {
     maxScale: userMaxScale = -1,
     scaleMode = ScaleMode.BOUNCE,
     panMode = PanMode.FREE,
-    panWithPinch = true,
+    panWithPinch = Platform.OS !== 'ios',
     mode = CropMode.MANAGED,
     onGestureActive = undefined,
     OverlayComponent = undefined,

--- a/src/components/resumable/ResumableZoom.tsx
+++ b/src/components/resumable/ResumableZoom.tsx
@@ -1,5 +1,10 @@
 import React, { useImperativeHandle } from 'react';
-import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
+import {
+  Platform,
+  View,
+  StyleSheet,
+  type LayoutChangeEvent,
+} from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useDerivedValue,
@@ -41,7 +46,7 @@ const ResumableZoom: React.FC<ResumableZoomProps> = (props) => {
     maxScale: userMaxScale = 6,
     panMode = PanMode.CLAMP,
     scaleMode = ScaleMode.BOUNCE,
-    panWithPinch = true,
+    panWithPinch = Platform.OS !== 'ios',
     onTap,
     onGestureActive,
     onSwipeRight,

--- a/src/components/resumable/ResumableZoom.tsx
+++ b/src/components/resumable/ResumableZoom.tsx
@@ -160,7 +160,7 @@ const ResumableZoom: React.FC<ResumableZoomProps> = (props) => {
   });
 
   const pinch = Gesture.Pinch()
-    .enabled(pinchEnabled && gesturesEnabled)
+    .enabled(pinchEnabled)
     .hitSlop(hitSlop)
     .onStart(onPinchStart)
     .onUpdate(onPinchUpdate)


### PR DESCRIPTION
- Fixes jump issue at the end of pan gesture, by disabling pan gesture at the beginning of pinch gesture, this prevent both gestures from colliding with each other.
- Makes panWithPinch feature opt in for iOS users because of this React Native Gesture Handler's [issue](https://github.com/software-mansion/react-native-gesture-handler/issues/2833), this one will be enabled by default again as soon as the next release of Gesture Handlers containing this [fix](https://github.com/software-mansion/react-native-gesture-handler/pull/2834) comes out.