### PR TITLE
[Gallery] feat: Added onZoomBegin and onZoomEnd callbacks for gallery

### DIFF
--- a/docs/docs/components/gallery.md
+++ b/docs/docs/components/gallery.md
@@ -261,14 +261,14 @@ Worklet callback triggered as the user scrolls the gallery.
 
 ### onZoomBegin
 | Type | Default |
-|------|---------|----------------|
+|------|---------|
 | `(index: number) => void` | `undefined` |
 
 Callback triggered when component is zoomed.
 
 ### onZoomEnd
 | Type | Default |
-|------|---------|----------------|
+|------|---------|
 | `(index: number) => void` | `undefined` |
 
 Callback triggered when component returns back to original state.

--- a/docs/docs/components/gallery.md
+++ b/docs/docs/components/gallery.md
@@ -259,6 +259,20 @@ Callback triggered as soon as the user lifts their fingers off the screen after 
 
 Worklet callback triggered as the user scrolls the gallery.
 
+### onZoomBegin
+| Type | Default |
+|------|---------|----------------|
+| `(index: number) => void` | `undefined` |
+
+Callback triggered when component is zoomed.
+
+### onZoomEnd
+| Type | Default |
+|------|---------|----------------|
+| `(index: number) => void` | `undefined` |
+
+Callback triggered when component returns back to original state.
+
 ### customTransition
 
 | Type | Default | Additional Info |

--- a/docs/docs/components/gallery.md
+++ b/docs/docs/components/gallery.md
@@ -249,6 +249,13 @@ This property is useful for instance to animate the background color based on th
 
 Callback triggered when the user swipes up, down, left or right.
 
+### onScroll
+| Type | Default | Additional Info |
+|------|---------|----------------|
+| `(scroll: number, contentOffset: number) => void` | `undefined` | see [worklets](https://docs.swmansion.com/react-native-reanimated/docs/2.x/fundamentals/worklets/) |
+
+Worklet callback triggered as the user scrolls the gallery.
+
 ### onPanStart
 | Type | Default | Additional Info |
 |------|---------|-----------------|
@@ -277,26 +284,19 @@ Callback triggered when the pinch gesture starts.
 
 Callback triggered as soon as the user lifts their fingers off the screen after pinching.
 
-### onScroll
-| Type | Default | Additional Info |
-|------|---------|----------------|
-| `(scroll: number, contentOffset: number) => void` | `undefined` | see [worklets](https://docs.swmansion.com/react-native-reanimated/docs/2.x/fundamentals/worklets/) |
-
-Worklet callback triggered as the user scrolls the gallery.
-
 ### onZoomBegin
 | Type | Default |
 |------|---------|
 | `(index: number) => void` | `undefined` |
 
-Callback triggered when component is zoomed.
+Callback triggered when component is zoomed from its base state (scale value at one).
 
 ### onZoomEnd
 | Type | Default |
 |------|---------|
 | `(index: number) => void` | `undefined` |
 
-Callback triggered when component returns back to original state.
+Callback triggered when component returns back to its original state (scale value at one).
 
 ### customTransition
 

--- a/src/commons/types.ts
+++ b/src/commons/types.ts
@@ -116,3 +116,8 @@ export type TapGestureCallbacks = Partial<{
   onTap: TapGestureEventCallback;
   onDoubleTap: TapGestureEventCallback;
 }>;
+
+export type ZoomEventCallbacks = Partial<{
+  onZoomBegin: (index: number) => void;
+  onZoomEnd: (index: number) => void;
+}>;

--- a/src/components/gallery/Gallery.tsx
+++ b/src/components/gallery/Gallery.tsx
@@ -42,6 +42,8 @@ const Gallery = <T extends unknown>(props: GalleryPropsWithRef<T>) => {
     onPinchStart,
     onPinchEnd,
     onSwipe,
+    onZoomBegin,
+    onZoomEnd,
   } = props;
 
   const allowPinchPanning = pinchPanning ?? getPanWithPinchStatus();
@@ -56,6 +58,7 @@ const Gallery = <T extends unknown>(props: GalleryPropsWithRef<T>) => {
     scroll,
     translate,
     scale,
+    hasZoomed,
   } = useContext(GalleryContext);
 
   const scrollDirection = useDerivedValue(() => {
@@ -112,6 +115,20 @@ const Gallery = <T extends unknown>(props: GalleryPropsWithRef<T>) => {
       scroll.value = activeIndex.value * direction;
     },
     [vertical, activeIndex, rootSize]
+  );
+
+  useAnimatedReaction(
+    () => scale.value,
+    (value, previousValue) => {
+      if (value !== 1 && !hasZoomed.value) {
+        hasZoomed.value = true;
+        onZoomBegin && runOnJS(onZoomBegin)(activeIndex.value);
+      } else if (value === 1 && previousValue !== 1 && hasZoomed.value) {
+        hasZoomed.value = false;
+        onZoomEnd && runOnJS(onZoomEnd)(activeIndex.value);
+      }
+    },
+    [scale]
   );
 
   const setIndex = (index: number) => {

--- a/src/components/gallery/GalleryProvider.tsx
+++ b/src/components/gallery/GalleryProvider.tsx
@@ -34,6 +34,8 @@ const GalleryProvider = <T extends unknown>(
   const resetIndex = useSharedValue<number>(startIndex);
   const fetchIndex = useSharedValue<number>(startIndex);
 
+  const hasZoomed = useSharedValue<boolean>(false);
+
   const context: GalleryContextType = {
     rootSize,
     rootChildSize,
@@ -45,6 +47,7 @@ const GalleryProvider = <T extends unknown>(
     fetchIndex,
     isScrolling,
     scale,
+    hasZoomed,
   };
 
   return (

--- a/src/components/gallery/context.ts
+++ b/src/components/gallery/context.ts
@@ -13,6 +13,7 @@ export type GalleryContextType = {
   resetIndex: SharedValue<number>;
   fetchIndex: SharedValue<number>;
   isScrolling: SharedValue<boolean>;
+  hasZoomed: SharedValue<boolean>;
 };
 
 export const GalleryContext = React.createContext<GalleryContextType>(

--- a/src/components/gallery/types.ts
+++ b/src/components/gallery/types.ts
@@ -5,6 +5,7 @@ import type {
   SizeVector,
   SwipeDirection,
   TapGestureEvent,
+  ZoomEventCallbacks,
 } from '../../commons/types';
 import type { ResumableZoomState } from '../resumable/types';
 
@@ -37,7 +38,8 @@ export type GalleryProps<T = unknown> = {
   onIndexChange?: (index: number) => void;
   onScroll?: (scroll: number, contentOffset: number) => void;
 } & PinchGestureCallbacks &
-  PanGestureCallbacks;
+  PanGestureCallbacks &
+  ZoomEventCallbacks;
 
 export type GalleryType = {
   setIndex: (index: number) => void;


### PR DESCRIPTION
I was the one who raised the issue, this is a code that I have written for gallery. I have not used other components therefore not added these callback support there as I haven't seen the code

These callbacks will support `index: number` to allow developers to have more control on the zoom event

### What is added?

| Name | Type | Default | Description|
|--------|------|---------|--------------|
| onZoomBegin | `(index: number) => void` | `undefined` | Callback triggered when component is zoomed. |
| onZoomEnd | `(index: number) => void` | `undefined` | Callback triggered when component returns back to original state. |

### How it works? 

```javascript  
useAnimatedReaction(
    () => scale.value,
    (value, previousValue) => {
      if (value !== 1 && !hasZoomed.value) { //if the value != 1, that means it is not in default state
        hasZoomed.value = true;
        onZoomBegin && runOnJS(onZoomBegin)(activeIndex.value);
      } else if (value === 1 && previousValue !== 1 && hasZoomed.value) { 
        /* 
          when the component is initally rendered, the value will be 1 and prevValue
            will not be 1, this condition will be true, and onZoomEnd() will be triggered
            to counter that, hasZoomed is used 
        */
        hasZoomed.value = false;
        onZoomEnd && runOnJS(onZoomEnd)(activeIndex.value);
      }
    },
    [scale]
  );
```

Note: I haven't tested the code snippet in iOS since I don't have macOS, but it is working as expected in android
