### PR TITLE
fix(Gallery): fix onVerticalPull and onSwipe overlap

### DIFF
--- a/src/commons/hooks/usePanCommons.ts
+++ b/src/commons/hooks/usePanCommons.ts
@@ -95,7 +95,6 @@ export const usePanCommons = (options: PanCommmonOptions) => {
 
     const toX = e.translationX + offset.x.value;
     const toY = e.translationY + offset.y.value;
-
     const toScale = clamp(scale.value, minScale, maxScale.value);
 
     const { x: boundX, y: boundY } = boundFn(toScale);
@@ -110,34 +109,33 @@ export const usePanCommons = (options: PanCommmonOptions) => {
       userCallbacks.onOverPanning(ex, ey);
     }
 
-    // Simplify both pan modes in one condition due to their similarity
+    // Simplify both free and clamp pan modes in one condition due to their similarity
     if (panMode !== PanMode.FRICTION) {
       const isFree = panMode === PanMode.FREE;
       translate.x.value = isFree ? toX : clamp(toX, -1 * boundX, boundX);
       translate.y.value = isFree ? toY : clamp(toY, -1 * boundY, boundY);
       detectorTranslate.x.value = translate.x.value;
       detectorTranslate.y.value = translate.y.value;
+      return;
     }
 
-    if (panMode === PanMode.FRICTION) {
-      const overScrollFraction =
-        Math.max(container.width.value, container.height.value) * 1.5;
+    const overScrollFraction =
+      Math.max(container.width.value, container.height.value) * 1.5;
 
-      if (isWithinBoundX.value) {
-        translate.x.value = toX;
-      } else {
-        const fraction = Math.abs(Math.abs(toX) - boundX) / overScrollFraction;
-        const frictionX = friction(clamp(fraction, 0, 1));
-        translate.x.value += e.changeX * frictionX;
-      }
+    if (isWithinBoundX.value) {
+      translate.x.value = toX;
+    } else {
+      const fraction = Math.abs(Math.abs(toX) - boundX) / overScrollFraction;
+      const frictionX = friction(clamp(fraction, 0, 1));
+      translate.x.value += e.changeX * frictionX;
+    }
 
-      if (isWithinBoundY.value) {
-        translate.y.value = toY;
-      } else {
-        const fraction = Math.abs(Math.abs(toY) - boundY) / overScrollFraction;
-        const frictionY = friction(clamp(fraction, 0, 1));
-        translate.y.value += e.changeY * frictionY;
-      }
+    if (isWithinBoundY.value) {
+      translate.y.value = toY;
+    } else {
+      const fraction = Math.abs(Math.abs(toY) - boundY) / overScrollFraction;
+      const frictionY = friction(clamp(fraction, 0, 1));
+      translate.y.value += e.changeY * frictionY;
     }
   };
 

--- a/src/commons/hooks/usePanCommons.ts
+++ b/src/commons/hooks/usePanCommons.ts
@@ -24,7 +24,7 @@ import {
   SwipeDirection,
 } from '../types';
 import { useVector } from './useVector';
-import getSwipeDirection from '../utils/getSwipeDirection';
+import { getSwipeDirection } from '../utils/getSwipeDirection';
 
 type PanCommmonOptions = {
   container: SizeVector<SharedValue<number>>;
@@ -33,15 +33,13 @@ type PanCommmonOptions = {
   offset: Vector<SharedValue<number>>;
   panMode: PanMode;
   scale: SharedValue<number>;
-  minScale: number;
-  maxScale: SharedValue<number>;
   decay?: boolean;
   boundFn: BoundsFuction;
   userCallbacks: Partial<{
     onGestureEnd: () => void;
-    onSwipe: (direction: SwipeDirection) => void;
     onPanStart: PanGestureEventCallback;
     onPanEnd: PanGestureEventCallback;
+    onSwipe: (direction: SwipeDirection) => void;
     onOverPanning: (x: number, y: number) => void;
   }>;
 };
@@ -60,8 +58,6 @@ export const usePanCommons = (options: PanCommmonOptions) => {
     offset,
     panMode,
     scale,
-    minScale,
-    maxScale,
     decay,
     boundFn,
     userCallbacks,
@@ -95,9 +91,8 @@ export const usePanCommons = (options: PanCommmonOptions) => {
 
     const toX = e.translationX + offset.x.value;
     const toY = e.translationY + offset.y.value;
-    const toScale = clamp(scale.value, minScale, maxScale.value);
 
-    const { x: boundX, y: boundY } = boundFn(toScale);
+    const { x: boundX, y: boundY } = boundFn(scale.value);
     const exceedX = Math.max(0, Math.abs(toX) - boundX);
     const exceedY = Math.max(0, Math.abs(toY) - boundY);
     isWithinBoundX.value = exceedX === 0;
@@ -159,8 +154,7 @@ export const usePanCommons = (options: PanCommmonOptions) => {
 
     userCallbacks.onPanEnd && runOnJS(userCallbacks.onPanEnd)(e);
 
-    const toScale = clamp(scale.value, minScale, maxScale.value);
-    const { x: boundX, y: boundY } = boundFn(toScale);
+    const { x: boundX, y: boundY } = boundFn(scale.value);
     const clampX: [number, number] = [-1 * boundX, boundX];
     const clampY: [number, number] = [-1 * boundY, boundY];
 

--- a/src/commons/hooks/usePanCommons.ts
+++ b/src/commons/hooks/usePanCommons.ts
@@ -167,8 +167,8 @@ export const usePanCommons = (options: PanCommmonOptions) => {
     const toX = clamp(translate.x.value, -1 * boundX, boundX);
     const toY = clamp(translate.y.value, -1 * boundY, boundY);
 
-    const shouldDecayX = decay && isWithinBoundX.value;
-    const shouldDecayY = decay && isWithinBoundY.value;
+    const decayX = decay && isWithinBoundX.value;
+    const decayY = decay && isWithinBoundY.value;
     const decayConfigX = {
       velocity: e.velocityX,
       clamp: clampX,
@@ -182,28 +182,24 @@ export const usePanCommons = (options: PanCommmonOptions) => {
     };
 
     detectorTranslate.x.value = translate.x.value;
-    detectorTranslate.x.value = shouldDecayX
+    detectorTranslate.x.value = decayX
       ? withDecay(decayConfigX)
       : withTiming(toX);
 
-    translate.x.value = shouldDecayX
-      ? withDecay(decayConfigX)
-      : withTiming(toX);
+    translate.x.value = decayX ? withDecay(decayConfigX) : withTiming(toX);
 
     detectorTranslate.y.value = translate.y.value;
-    detectorTranslate.y.value = shouldDecayY
+    detectorTranslate.y.value = decayY
       ? withDecay(decayConfigY)
       : withTiming(toY);
 
-    translate.y.value = shouldDecayY
-      ? withDecay(decayConfigY)
-      : withTiming(toY);
+    translate.y.value = decayY ? withDecay(decayConfigY) : withTiming(toY);
 
     const restX = Math.max(0, Math.abs(translate.x.value) - boundX);
     const restY = Math.max(0, Math.abs(translate.y.value) - boundY);
     gestureEnd.value = restX > restY ? translate.x.value : translate.y.value;
 
-    if (shouldDecayX && shouldDecayY) {
+    if (decayX && decayY) {
       const config = restX > restY ? decayConfigX : decayConfigY;
       gestureEnd.value = withDecay(config, (finished) => {
         if (finished && userCallbacks.onGestureEnd) {

--- a/src/commons/hooks/usePinchCommons.ts
+++ b/src/commons/hooks/usePinchCommons.ts
@@ -151,8 +151,8 @@ export const usePinchCommons = (options: PinchOptions) => {
 
     translate.x.value = withTiming(toX);
     translate.y.value = withTiming(toY);
-    scale.value = withTiming(toScale, undefined, () => {
-      runOnJS(switchGesturesState)(true);
+    scale.value = withTiming(toScale, undefined, (finished) => {
+      finished && runOnJS(switchGesturesState)(true);
     });
 
     gestureEnd.value = withTiming(toValue, undefined, (finished) => {

--- a/src/commons/utils/getSwipeDirection.ts
+++ b/src/commons/utils/getSwipeDirection.ts
@@ -11,10 +11,10 @@ const SWIPE_TIME = 175;
 const SWIPE_VELOCITY = 500;
 const SWIPE_DISTANCE = 20;
 
-export default function getSwipeDirection(
+export const getSwipeDirection = (
   e: PanGestureEvent,
   options: SwipeDirectionOptions
-): SwipeDirection | undefined {
+): SwipeDirection | undefined => {
   'worklet';
 
   const { time, boundaries, position, translate } = options;
@@ -57,4 +57,4 @@ export default function getSwipeDirection(
   if (swipeDown && inLowerBound) return SwipeDirection.DOWN;
 
   return undefined;
-}
+};

--- a/src/commons/utils/getSwipeDirection.ts
+++ b/src/commons/utils/getSwipeDirection.ts
@@ -24,37 +24,37 @@ export default function getSwipeDirection(
   const deltaY = Math.abs(position.y - e.absoluteY);
   const { x: boundX, y: boundY } = boundaries;
 
-  const swipeR =
+  const swipeRight =
     e.velocityX >= SWIPE_VELOCITY &&
     deltaX >= SWIPE_DISTANCE &&
     deltaTime <= SWIPE_TIME;
 
   const inRightBound = translate.x === boundX;
-  if (swipeR && inRightBound) return SwipeDirection.RIGHT;
+  if (swipeRight && inRightBound) return SwipeDirection.RIGHT;
 
-  const swipeL =
+  const swipeLeft =
     e.velocityX <= -1 * SWIPE_VELOCITY &&
     deltaX >= SWIPE_DISTANCE &&
     deltaTime <= SWIPE_TIME;
 
   const inLeftBound = translate.x === -1 * boundX;
-  if (swipeL && inLeftBound) return SwipeDirection.LEFT;
+  if (swipeLeft && inLeftBound) return SwipeDirection.LEFT;
 
-  const swipeU =
+  const swipeUp =
     e.velocityY <= -1 * SWIPE_VELOCITY &&
     deltaY >= SWIPE_DISTANCE &&
     deltaTime <= SWIPE_TIME;
 
   const inUpperBound = translate.y === -1 * boundY;
-  if (swipeU && inUpperBound) return SwipeDirection.UP;
+  if (swipeUp && inUpperBound) return SwipeDirection.UP;
 
-  const swipeD =
+  const swipeDown =
     e.velocityY >= SWIPE_VELOCITY &&
     deltaY >= SWIPE_DISTANCE &&
     deltaTime <= SWIPE_TIME;
 
   const inLowerBound = translate.y === boundY;
-  if (swipeD && inLowerBound) return SwipeDirection.DOWN;
+  if (swipeDown && inLowerBound) return SwipeDirection.DOWN;
 
   return undefined;
 }

--- a/src/components/crop/CropZoom.tsx
+++ b/src/components/crop/CropZoom.tsx
@@ -172,8 +172,6 @@ const CropZoom: React.FC<CropZoomProps> = (props) => {
     translate,
     offset,
     scale,
-    minScale,
-    maxScale,
     detectorTranslate,
     panMode,
     boundFn: boundsFn,

--- a/src/components/gallery/Gallery.tsx
+++ b/src/components/gallery/Gallery.tsx
@@ -87,7 +87,9 @@ const Gallery = <T extends unknown>(props: GalleryPropsWithRef<T>) => {
   const measureRoot = (e: LayoutChangeEvent) => {
     rootSize.width.value = e.nativeEvent.layout.width;
     rootSize.height.value = e.nativeEvent.layout.height;
-    scroll.value = activeIndex.value * e.nativeEvent.layout.width;
+
+    const direction = vertical ? rootSize.width.value : rootSize.height.value;
+    scroll.value = activeIndex.value * direction;
   };
 
   useAnimatedReaction(
@@ -133,7 +135,7 @@ const Gallery = <T extends unknown>(props: GalleryPropsWithRef<T>) => {
 
   // Reference handling
   const setIndex = (index: number) => {
-    const clamped = clamp(index, 0, data.length);
+    const clamped = clamp(index, 0, data.length - 1);
     activeIndex.value = clamped;
     fetchIndex.value = clamped;
     scroll.value = clamped * itemSize.value;
@@ -162,19 +164,16 @@ const Gallery = <T extends unknown>(props: GalleryPropsWithRef<T>) => {
   return (
     <GestureHandlerRootView style={styles.root} onLayout={measureRoot}>
       {data.map((item, index) => {
-        if (
-          index < scrollIndex - nextItems ||
-          index > scrollIndex + nextItems
-        ) {
-          return null;
-        }
+        const inLowerHalf = index < scrollIndex - nextItems;
+        const inUpperHalf = index > scrollIndex + nextItems;
+        if (inLowerHalf || inUpperHalf) return null;
 
         const key = keyExtractor?.(item, index) ?? `item-${index}`;
 
         return (
           <GalleryItem
             key={key}
-            count={data.length}
+            zIndex={data.length - index}
             index={index}
             item={item}
             vertical={vertical}

--- a/src/components/gallery/GalleryItem.tsx
+++ b/src/components/gallery/GalleryItem.tsx
@@ -31,21 +31,21 @@ const GalleryItem: React.FC<GalleryItemProps> = ({
 }) => {
   const {
     rootSize,
-    activeIndex,
     rootChildSize,
+    activeIndex,
     scroll,
     isScrolling,
     translate,
     scale,
   } = useContext(GalleryContext);
 
-  const childSize = useSizeVector(0, 0);
+  const itemSize = useSizeVector(0, 0);
   const innerTranslate = useVector(0, 0);
   const innerScale = useSharedValue<number>(1);
 
   const measureChild = (e: LayoutChangeEvent) => {
-    childSize.width.value = e.nativeEvent.layout.width;
-    childSize.height.value = e.nativeEvent.layout.height;
+    itemSize.width.value = e.nativeEvent.layout.width;
+    itemSize.height.value = e.nativeEvent.layout.height;
 
     if (index === activeIndex.value) {
       rootChildSize.width.value = e.nativeEvent.layout.width;
@@ -100,8 +100,8 @@ const GalleryItem: React.FC<GalleryItemProps> = ({
     () => activeIndex.value,
     (value) => {
       if (index === value) {
-        rootChildSize.width.value = childSize.width.value;
-        rootChildSize.height.value = childSize.height.value;
+        rootChildSize.width.value = itemSize.width.value;
+        rootChildSize.height.value = itemSize.height.value;
       } else {
         innerTranslate.x.value = 0;
         innerTranslate.y.value = 0;

--- a/src/components/gallery/GalleryItem.tsx
+++ b/src/components/gallery/GalleryItem.tsx
@@ -3,7 +3,6 @@ import { StyleSheet, type LayoutChangeEvent } from 'react-native';
 import Animated, {
   useAnimatedReaction,
   useAnimatedStyle,
-  useDerivedValue,
   useSharedValue,
 } from 'react-native-reanimated';
 
@@ -15,15 +14,15 @@ import type { GalleryTransitionCallback } from './types';
 type GalleryItemProps = {
   item: any;
   index: number;
-  count: number;
+  zIndex: number;
   vertical: boolean;
   renderItem: (item: any, index: number) => React.ReactElement;
   customTransition?: GalleryTransitionCallback;
 };
 
 const GalleryItem: React.FC<GalleryItemProps> = ({
-  count,
   index,
+  zIndex,
   item,
   vertical,
   renderItem,
@@ -39,13 +38,13 @@ const GalleryItem: React.FC<GalleryItemProps> = ({
     scale,
   } = useContext(GalleryContext);
 
-  const itemSize = useSizeVector(0, 0);
+  const innerSize = useSizeVector(0, 0);
   const innerTranslate = useVector(0, 0);
   const innerScale = useSharedValue<number>(1);
 
   const measureChild = (e: LayoutChangeEvent) => {
-    itemSize.width.value = e.nativeEvent.layout.width;
-    itemSize.height.value = e.nativeEvent.layout.height;
+    innerSize.width.value = e.nativeEvent.layout.width;
+    innerSize.height.value = e.nativeEvent.layout.height;
 
     if (index === activeIndex.value) {
       rootChildSize.width.value = e.nativeEvent.layout.width;
@@ -61,7 +60,7 @@ const GalleryItem: React.FC<GalleryItemProps> = ({
         { scale: innerScale.value },
       ],
     };
-  });
+  }, [innerTranslate, innerScale]);
 
   const transitionStyle = useAnimatedStyle(() => {
     if (customTransition !== undefined) {
@@ -88,33 +87,38 @@ const GalleryItem: React.FC<GalleryItemProps> = ({
     return { transform: [{ translateX }], opacity };
   });
 
-  useDerivedValue(() => {
-    if (index === activeIndex.value) {
-      innerTranslate.x.value = translate.x.value;
-      innerTranslate.y.value = translate.y.value;
-      innerScale.value = scale.value;
-    }
-  }, [activeIndex, translate, scale]);
+  useAnimatedReaction(
+    () => ({
+      activeIndex: activeIndex.value,
+      translate: { x: translate.x.value, y: translate.y.value },
+      scale: scale.value,
+    }),
+    (current) => {
+      if (index !== current.activeIndex) return;
+      innerTranslate.x.value = current.translate.x;
+      innerTranslate.y.value = current.translate.y;
+      innerScale.value = current.scale;
+    },
+    [activeIndex, translate, scale]
+  );
 
   useAnimatedReaction(
     () => activeIndex.value,
     (value) => {
       if (index === value) {
-        rootChildSize.width.value = itemSize.width.value;
-        rootChildSize.height.value = itemSize.height.value;
+        rootChildSize.width.value = innerSize.width.value;
+        rootChildSize.height.value = innerSize.height.value;
       } else {
         innerTranslate.x.value = 0;
         innerTranslate.y.value = 0;
         innerScale.value = 1;
       }
     },
-    [activeIndex]
+    [activeIndex, innerSize]
   );
 
   return (
-    <Animated.View
-      style={[styles.root, { zIndex: count - index }, transitionStyle]}
-    >
+    <Animated.View style={[styles.root, transitionStyle, { zIndex }]}>
       <Animated.View style={childStyle} onLayout={measureChild}>
         {renderItem(item, index)}
       </Animated.View>
@@ -135,8 +139,8 @@ const styles = StyleSheet.create({
 
 export default React.memo(GalleryItem, (prev, next) => {
   return (
-    prev.count === next.count &&
     prev.index === next.index &&
+    prev.zIndex === next.zIndex &&
     prev.vertical === next.vertical &&
     prev.customTransition === next.customTransition &&
     prev.renderItem === next.renderItem

--- a/src/components/gallery/GalleryProvider.tsx
+++ b/src/components/gallery/GalleryProvider.tsx
@@ -5,10 +5,9 @@ import { clamp } from '../../commons/utils/clamp';
 import { useVector } from '../../commons/hooks/useVector';
 import { useSizeVector } from '../../commons/hooks/useSizeVector';
 
-import type { GalleryProps, GalleryType } from './types';
-
 import Gallery from './Gallery';
 import { GalleryContext, type GalleryContextType } from './context';
+import type { GalleryProps, GalleryType } from './types';
 
 type GalleryPropsWithRef<T> = GalleryProps<T> & {
   ref: React.ForwardedRef<GalleryType>;

--- a/src/components/gallery/GalleryProvider.tsx
+++ b/src/components/gallery/GalleryProvider.tsx
@@ -9,12 +9,8 @@ import Gallery from './Gallery';
 import { GalleryContext, type GalleryContextType } from './context';
 import type { GalleryProps, GalleryType } from './types';
 
-type GalleryPropsWithRef<T> = GalleryProps<T> & {
-  ref: React.ForwardedRef<GalleryType>;
-};
-
 const GalleryProvider = <T extends unknown>(
-  props: GalleryPropsWithRef<T>,
+  props: GalleryProps<T>,
   ref: React.ForwardedRef<GalleryType>
 ) => {
   const startIndex = clamp(props.initialIndex ?? 0, 0, props.data.length - 1);
@@ -54,6 +50,10 @@ const GalleryProvider = <T extends unknown>(
       <Gallery {...props} reference={ref} />
     </GalleryContext.Provider>
   );
+};
+
+type GalleryPropsWithRef<T> = GalleryProps<T> & {
+  ref: React.ForwardedRef<GalleryType>;
 };
 
 export default forwardRef(GalleryProvider) as <T>(

--- a/src/components/gallery/Reflection.tsx
+++ b/src/components/gallery/Reflection.tsx
@@ -297,8 +297,8 @@ const Reflection = ({
         return;
       }
 
-      direction === undefined && snapToScrollPosition(e);
       onPanEnd && runOnJS(onPanEnd)(e);
+      direction === undefined && snapToScrollPosition(e);
 
       const clampX: [number, number] = [-1 * boundaries.x, boundaries.x];
       const clampY: [number, number] = [-1 * boundaries.y, boundaries.y];
@@ -322,9 +322,7 @@ const Reflection = ({
         height: rootSize.height.value,
       };
 
-      const {
-        crop: { originX, width },
-      } = crop({
+      const { crop: result } = crop({
         scale: scale.value,
         context: {
           flipHorizontal: false,
@@ -338,8 +336,8 @@ const Reflection = ({
       });
 
       const tapEdge = 44 / scale.value;
-      const leftEdge = originX + tapEdge;
-      const rightEdge = originX + width - tapEdge;
+      const leftEdge = result.originX + tapEdge;
+      const rightEdge = result.originX + result.width - tapEdge;
 
       let toIndex = activeIndex.value;
       const canGoToItem = tapOnEdgeToItem && !vertical;

--- a/src/components/resumable/ResumableZoom.tsx
+++ b/src/components/resumable/ResumableZoom.tsx
@@ -171,8 +171,6 @@ const ResumableZoom: React.FC<ResumableZoomProps> = (props) => {
     translate,
     offset,
     scale,
-    minScale,
-    maxScale,
     panMode,
     boundFn: boundsFn,
     decay,

--- a/src/components/snapback/SnapbackZoom.tsx
+++ b/src/components/snapback/SnapbackZoom.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { StyleSheet } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   measure,
   runOnJS,
@@ -10,6 +9,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 import { useVector } from '../../commons/hooks/useVector';
 import { useSizeVector } from '../../commons/hooks/useSizeVector';
@@ -33,8 +33,8 @@ const SnapbackZoom: React.FC<SnapBackZoomProps> = ({
   onGestureEnd,
 }) => {
   const [internalGesturesEnabled, setGesturesEnabled] = useState<boolean>(true);
-  const toggleGestures = () => {
-    setGesturesEnabled((prev) => !prev);
+  const switchGestureStatus = (enabled: boolean) => {
+    setGesturesEnabled(enabled);
   };
 
   const position = useVector(0, 0);
@@ -89,9 +89,7 @@ const SnapbackZoom: React.FC<SnapBackZoomProps> = ({
     .hitSlop(hitSlop)
     .enabled(gesturesEnabled && internalGesturesEnabled)
     .onStart((e) => {
-      if (onPinchStart !== undefined) {
-        runOnJS(onPinchStart)(e);
-      }
+      onPinchStart && runOnJS(onPinchStart)(e);
 
       measurePinchContainer();
       origin.x.value = e.focalX - containerSize.width.value / 2;
@@ -109,20 +107,14 @@ const SnapbackZoom: React.FC<SnapBackZoomProps> = ({
       scale.value = e.scale;
     })
     .onEnd((e) => {
-      runOnJS(toggleGestures)();
-
-      if (onPinchEnd !== undefined) {
-        runOnJS(onPinchEnd)(e);
-      }
+      runOnJS(switchGestureStatus)(false);
+      onPinchEnd && runOnJS(onPinchEnd)(e);
 
       translate.x.value = withTiming(0, timingConfig);
       translate.y.value = withTiming(0, timingConfig);
       scale.value = withTiming(1, timingConfig, (_) => {
-        runOnJS(toggleGestures)();
-
-        if (onGestureEnd !== undefined) {
-          runOnJS(onGestureEnd)();
-        }
+        runOnJS(switchGestureStatus)(true);
+        onGestureEnd && runOnJS(onGestureEnd)();
       });
     });
 


### PR DESCRIPTION
- Fixes the overlap between the properties in the title, where onVerticalPull would prevent the detection of vertical swipes.
- Related to the issue above, setting the Gallery to vertical mode would not snap back to an item if a swipe horizontal was made.