### PR TITLE
fix(Gallery): fix incorrect gesture direction detection

### DIFF
--- a/src/components/gallery/Reflection.tsx
+++ b/src/components/gallery/Reflection.tsx
@@ -253,6 +253,7 @@ const Reflection = ({
   const pan = Gesture.Pan()
     .withTestId('pan')
     .maxPointers(1)
+    .minVelocity(100)
     .enabled(gesturesEnabled)
     .onStart((e) => {
       onPanStart && runOnJS(onPanStart)(e);


### PR DESCRIPTION
When we use the `onVerticalPull` callback together with horizontal switching of images in the gallery, the direction detection often works incorrectly because the direction detection is based on a weak gesture which can be detected incorrectly.

I added `minVelocity(100)` and it fixed the problem