### PR TITLE
fix(example): add iOS Expo Media Library permissions to prevent crash

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -29,6 +29,15 @@
       "favicon": "./assets/favicon.png",
       "bundler": "metro"
     },
-    "plugins": ["expo-router"]
+    "plugins": [
+      "expo-router",
+      [
+        "expo-media-library",
+        {
+          "photosPermission": "Allow $(PRODUCT_NAME) to access your photos.",
+          "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos."
+        }
+      ]
+    ]
   }
 }


### PR DESCRIPTION
## Summary

This pull request adds the required iOS permission configurations for `expo-media-library` to the example app's `app.json` to fix a crash when accessing the photo gallery on iOS devices.

## Describe your changes

* Added the `expo-media-library` config plugin to `example/app.json` with `photosPermission` and `savePhotosPermission` keys.
* Prevents the app from crashing due to missing `NSPhotoLibraryUsageDescription` and `NSPhotoLibraryAddUsageDescription` keys in the native iOS `Info.plist`.
* No changes to the main library API or implementation.
* Fixes the iOS crash in the GalleryExample screen and allows saving cropped images without freezing the UI.

## Footage

*No UI changes; fix affects native config only.*

## Pull Request Type

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Other

## Terms of service

* [x] I've followed the guidelines in [CONTRIBUTING](https://github.com/Glazzes/react-native-zoomable/blob/main/CONTRIBUTING.md) document.
