### PR TITLE
fix: update BlocksGesture type to allow null React RefObjects

### DIFF
--- a/src/components/snapback/types.ts
+++ b/src/components/snapback/types.ts
@@ -19,7 +19,9 @@ import type {
 export type BlocksGesture =
   | GestureType
   | React.RefObject<GestureType | undefined>
-  | React.RefObject<React.ComponentType<{}> | undefined>;
+  | React.RefObject<GestureType | null>
+  | React.RefObject<React.ComponentType<{}> | undefined>
+  | React.RefObject<React.ComponentType<{}> | null>;
 
 export type TimingConfig = Partial<{
   duration: number;


### PR DESCRIPTION
## Change

Add nullable type to React.RefObject typings for `scrollRef` for better compatibility with many React 19 RefObjects.

## Reasoning

### It reflects real React types better

React states that when a view (like ScrollView, which is a subtype of GestureType) unmounts:

> [React will set the current property back to null when the node is removed from the screen.](https://react.dev/reference/react/useRef#:~:text=React%20will%20set%20the%20current%20property%20back%20to%20null%20when%20the%20node%20is%20removed%20from%20the%20screen.)

This means that in reality, all refs can become null, so `RefObject<GestureType | null>` is a more accurate reflection of the type, especially if the ref is initialized to null using `useRef<GestureType>(null)`

Currently, the typings for BlocksGesture only support undefined refs. This commit adds support for that typing, but leaves the undefined typing for backwards compatibility.

### It doesn't change behavior

1. We pass the ref to [blocksExternalGesture](https://github.com/software-mansion/react-native-gesture-handler/blob/1427aae2656d9b407a77916379ea718e0503cf20/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts#L384)
2. That function just checks `if (gesture)`, which treats null and undefined the same