### PR TITLE
fix(pinch): stop native-stack overflow on rapid pinch under Reanimated 4

### DIFF
--- a/src/commons/hooks/usePinchCommons.ts
+++ b/src/commons/hooks/usePinchCommons.ts
@@ -179,9 +179,18 @@ export const usePinchCommons = (options: PinchOptions) => {
     });
 
     gestureEnd.value = withTiming(toValue, undefined, (finished) => {
-      gestureEnd.value = 0;
-      if (finished && userCallbacks.onGestureEnd !== undefined) {
-        scheduleOnRN(userCallbacks.onGestureEnd);
+      // Only re-arm the gimmick on a genuine finish. Writing gestureEnd.value
+      // unconditionally here re-enters this callback via Reanimated 4.x's
+      // valueSetter (it fires a still-live animation's callback(false) before
+      // clearing _animation when the value is overwritten), recursing to a
+      // native-stack overflow on rapid pinch in/out. Gating on `finished`
+      // mirrors usePanCommons (which never self-writes) and keeps the callback
+      // re-entry a single no-op level deep. See issue #126.
+      if (finished) {
+        gestureEnd.value = 0;
+        if (userCallbacks.onGestureEnd !== undefined) {
+          scheduleOnRN(userCallbacks.onGestureEnd);
+        }
       }
     });
   };


### PR DESCRIPTION
Fixes #126.

`usePinchCommons` `reset()` wrote `gestureEnd.value` inside its own `withTiming` callback **unconditionally**. Under Reanimated 4.x, `valueSetter` invokes a still-live animation's `callback(false)` when the value is overwritten/cancelled **before** clearing `_animation`, so the self-write re-enters the same callback and recurses to `Maximum call stack size exceeded (native stack depth)` on rapid pinch in/out.

This gates the reset on `finished`, mirroring `usePanCommons` (which never self-writes the shared value). On a real finish it writes once and the re-entrant `finished === false` call is a single no-op level deep; on cancel it never writes. `gestureEnd` is an internal gimmick (never read in a style), so the change is behavior-preserving.

Verified on-device (iOS, RN 0.86, Reanimated 4.5.0): rapid pinch in/out no longer overflows the native stack.