### PR TITLE
feat(Gallery): configurable snap threshold for page changes

### DIFF
--- a/docs/docs/components/gallery.md
+++ b/docs/docs/components/gallery.md
@@ -76,6 +76,7 @@ const GalleryExample = () => {
       keyExtractor={keyExtractor}
       renderItem={renderItem}
       onTap={onTap}
+      snapThreshold={0.25}
       customTransition={transition}
     />
   );
@@ -200,6 +201,52 @@ Modify the orientation of the component to vertical mode.
 | `object` | `{duration: 300, easing: Easing.out(Easing.cubic)}` | see [timingConfig](https://docs.swmansion.com/react-native-reanimated/docs/animations/withTiming/#config-) |
 
 Set the timing config used to snap between gallery's elements.
+
+### snapThreshold
+
+| Type     | Default |
+| -------- | ------- |
+| `number` | `0.5`   |
+
+Fraction of the distance between pages that must be dragged before changing to the previous or next item.
+Values are clamped between `0` and `1`. Lower values make page changes require a shorter drag in both
+horizontal and vertical galleries.
+
+For TikTok-style vertical paging, for example:
+
+```tsx
+<Gallery
+  data={items}
+  renderItem={renderItem}
+  vertical={true}
+  snapThreshold={0.2}
+/>
+```
+
+### swipeVelocityThreshold
+
+| Type     | Default |
+| -------- | ------- |
+| `number` | `500`   |
+
+Minimum pan velocity in points per second that triggers a page swipe. This is independent of
+`snapThreshold`: quick flings can change pages without crossing the configured distance threshold.
+
+### swipeTimeThreshold
+
+| Type     | Default |
+| -------- | ------- |
+| `number` | `175`   |
+
+Maximum pan duration in milliseconds that can be recognized as a swipe.
+
+### swipeDistanceThreshold
+
+| Type     | Default |
+| -------- | ------- |
+| `number` | `20`    |
+
+Minimum pan distance in points required before a swipe can change pages.
 
 ### maxScale
 

--- a/example/src/gallery/GalleryExample.tsx
+++ b/example/src/gallery/GalleryExample.tsx
@@ -135,6 +135,7 @@ export default function GalleryExample() {
         renderItem={renderItem}
         gap={24}
         maxScale={scales}
+        snapThreshold={0.25}
         onIndexChange={(idx) => {
           activeIndex.value = idx;
         }}

--- a/src/__tests__/commons/getSwipeDirection.test.ts
+++ b/src/__tests__/commons/getSwipeDirection.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import type { PanGestureEvent } from '../../commons/types';
+import { getSwipeDirection } from '../../commons/utils/getSwipeDirection';
+
+declare const performance: { now: () => number };
+
+const createEvent = (absoluteX: number, velocityX: number): PanGestureEvent =>
+  ({
+    absoluteX,
+    absoluteY: 0,
+    velocityX,
+    velocityY: 0,
+  }) as PanGestureEvent;
+
+const options = {
+  time: 0,
+  boundaries: { x: 0, y: 0 },
+  position: { x: 0, y: 0 },
+  translate: { x: 0, y: 0 },
+};
+
+describe('getSwipeDirection', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('preserves the default swipe thresholds', () => {
+    const now = jest.spyOn(performance, 'now').mockReturnValue(175);
+
+    expect(getSwipeDirection(createEvent(-20, -500), options)).toBe('left');
+    expect(getSwipeDirection(createEvent(-20, -499), options)).toBeUndefined();
+    expect(getSwipeDirection(createEvent(-19, -500), options)).toBeUndefined();
+
+    now.mockReturnValue(176);
+    expect(getSwipeDirection(createEvent(-20, -500), options)).toBeUndefined();
+  });
+
+  it('supports custom swipe thresholds', () => {
+    jest.spyOn(performance, 'now').mockReturnValue(200);
+
+    expect(
+      getSwipeDirection(createEvent(-10, -200), {
+        ...options,
+        timeThreshold: 200,
+        velocityThreshold: 200,
+        distanceThreshold: 10,
+      })
+    ).toBe('left');
+  });
+});

--- a/src/__tests__/gestures/GalleryGestures.test.tsx
+++ b/src/__tests__/gestures/GalleryGestures.test.tsx
@@ -56,6 +56,24 @@ describe('Gallery Gesture Tests', () => {
     jest.runAllTimers();
   };
 
+  const panToNextItem = (vertical: boolean, distance: number, velocity = 0) => {
+    const start = { absoluteX: 50, absoluteY: 300 };
+    const translation = vertical
+      ? { translationY: -distance, velocityY: -velocity }
+      : { translationX: -distance, velocityX: -velocity };
+    const end = vertical
+      ? { absoluteX: 50, absoluteY: start.absoluteY - distance }
+      : { absoluteX: start.absoluteX - distance, absoluteY: 300 };
+
+    fireGestureHandler<PanGesture>(getByGestureTestId('pan'), [
+      { state: State.BEGAN, ...start },
+      { state: State.ACTIVE, ...start },
+      { state: State.ACTIVE, ...end, ...translation },
+      { state: State.END, ...end, ...translation },
+    ]);
+    jest.runAllTimers();
+  };
+
   it('should trigger gesture callbacks', () => {
     const onPanStart = jest.fn();
     const onPanEnd = jest.fn();
@@ -151,5 +169,66 @@ describe('Gallery Gesture Tests', () => {
     expect(onPinchEnd).toHaveBeenCalledTimes(timesCalled);
     expect(onGestureEnd).toHaveBeenCalledTimes(timesCalled * 2);
     expect(ref.current?.getState().scale).toBe(expectedScale);
+  });
+
+  it.each([
+    {
+      title: 'changes horizontal pages at a custom snap threshold',
+      vertical: false,
+      distance: 20,
+    },
+    {
+      title: 'changes vertical pages at a custom snap threshold',
+      vertical: true,
+      distance: 120,
+    },
+  ])('$title', ({ vertical, distance }) => {
+    const onIndexChange = jest.fn();
+    renderGallery({ vertical, snapThreshold: 0.2, onIndexChange });
+
+    panToNextItem(vertical, distance);
+
+    expect(onIndexChange).toHaveBeenLastCalledWith(1);
+  });
+
+  it('keeps the default halfway snap threshold', () => {
+    const onIndexChange = jest.fn();
+    renderGallery({ onIndexChange });
+
+    panToNextItem(false, 49);
+
+    expect(onIndexChange).not.toHaveBeenCalledWith(1);
+
+    panToNextItem(false, 51);
+
+    expect(onIndexChange).toHaveBeenLastCalledWith(1);
+  });
+
+  it('changes pages at a custom swipe velocity threshold', () => {
+    const onIndexChange = jest.fn();
+    renderGallery({
+      vertical: true,
+      snapThreshold: 0.9,
+      swipeVelocityThreshold: 200,
+      onIndexChange,
+    });
+
+    panToNextItem(true, 30, 250);
+
+    expect(onIndexChange).toHaveBeenLastCalledWith(1);
+  });
+
+  it('changes pages at a custom swipe distance threshold', () => {
+    const onIndexChange = jest.fn();
+    renderGallery({
+      vertical: true,
+      snapThreshold: 0.9,
+      swipeDistanceThreshold: 10,
+      onIndexChange,
+    });
+
+    panToNextItem(true, 10, 500);
+
+    expect(onIndexChange).toHaveBeenLastCalledWith(1);
   });
 });

--- a/src/commons/utils/getSwipeDirection.ts
+++ b/src/commons/utils/getSwipeDirection.ts
@@ -5,11 +5,14 @@ type SwipeOptions = {
   boundaries: Vector<number>;
   position: Vector<number>;
   translate: Vector<number>;
+  timeThreshold?: number;
+  velocityThreshold?: number;
+  distanceThreshold?: number;
 };
 
-const SWIPE_TIME = 175;
-const SWIPE_VELOCITY = 500;
-const SWIPE_DISTANCE = 20;
+const DEFAULT_SWIPE_TIME_THRESHOLD = 175;
+const DEFAULT_SWIPE_VELOCITY_THRESHOLD = 500;
+const DEFAULT_SWIPE_DISTANCE_THRESHOLD = 20;
 
 export const getSwipeDirection = (
   e: PanGestureEvent,
@@ -18,35 +21,61 @@ export const getSwipeDirection = (
   'worklet';
 
   const { time, boundaries, position, translate } = options;
+  const timeThreshold = Math.max(
+    0,
+    options.timeThreshold ?? DEFAULT_SWIPE_TIME_THRESHOLD
+  );
+  const velocityThreshold = Math.max(
+    0,
+    options.velocityThreshold ?? DEFAULT_SWIPE_VELOCITY_THRESHOLD
+  );
+  const distanceThreshold = Math.max(
+    0,
+    options.distanceThreshold ?? DEFAULT_SWIPE_DISTANCE_THRESHOLD
+  );
 
   // @ts-ignore
   const deltaTime = performance.now() - time;
   const { x: boundX, y: boundY } = boundaries;
 
-  const swipedDistanceX = Math.abs(position.x - e.absoluteX) >= SWIPE_DISTANCE;
-  const swipedDistanceY = Math.abs(position.y - e.absoluteY) >= SWIPE_DISTANCE;
-  const swipedInTime = deltaTime <= SWIPE_TIME;
+  const swipedDistanceX =
+    Math.abs(position.x - e.absoluteX) >= distanceThreshold;
+  const swipedDistanceY =
+    Math.abs(position.y - e.absoluteY) >= distanceThreshold;
+  const swipedInTime = deltaTime <= timeThreshold;
 
   const swipeRight =
-    e.velocityX >= SWIPE_VELOCITY && swipedDistanceX && swipedInTime;
+    e.velocityX > 0 &&
+    e.velocityX >= velocityThreshold &&
+    swipedDistanceX &&
+    swipedInTime;
 
   const inRightBound = translate.x === boundX;
   if (swipeRight && inRightBound) return 'right';
 
   const swipeLeft =
-    e.velocityX <= -1 * SWIPE_VELOCITY && swipedDistanceX && swipedInTime;
+    e.velocityX < 0 &&
+    e.velocityX <= -1 * velocityThreshold &&
+    swipedDistanceX &&
+    swipedInTime;
 
   const inLeftBound = translate.x === -1 * boundX;
   if (swipeLeft && inLeftBound) return 'left';
 
   const swipeUp =
-    e.velocityY <= -1 * SWIPE_VELOCITY && swipedDistanceY && swipedInTime;
+    e.velocityY < 0 &&
+    e.velocityY <= -1 * velocityThreshold &&
+    swipedDistanceY &&
+    swipedInTime;
 
   const inUpperBound = translate.y === -1 * boundY;
   if (swipeUp && inUpperBound) return 'up';
 
   const swipeDown =
-    e.velocityY >= SWIPE_VELOCITY && swipedDistanceY && swipedInTime;
+    e.velocityY > 0 &&
+    e.velocityY >= velocityThreshold &&
+    swipedDistanceY &&
+    swipedInTime;
 
   const inLowerBound = translate.y === boundY;
   if (swipeDown && inLowerBound) return 'down';

--- a/src/components/gallery/Gallery.tsx
+++ b/src/components/gallery/Gallery.tsx
@@ -46,6 +46,10 @@ const Gallery = <T,>(props: GalleryPropsWithRef<T>) => {
     allowPinchPanning = true,
     longPressDuration = 500,
     snapTimingConfig = defaultTimingConfig,
+    snapThreshold = 0.5,
+    swipeTimeThreshold = 175,
+    swipeVelocityThreshold = 500,
+    swipeDistanceThreshold = 20,
     customTransition,
     onIndexChange,
     onScroll,
@@ -278,6 +282,10 @@ const Gallery = <T,>(props: GalleryPropsWithRef<T>) => {
         pinchMode={pinchMode}
         longPressDuration={longPressDuration}
         snapTimingConfig={snapTimingConfig}
+        snapThreshold={snapThreshold}
+        swipeTimeThreshold={swipeTimeThreshold}
+        swipeVelocityThreshold={swipeVelocityThreshold}
+        swipeDistanceThreshold={swipeDistanceThreshold}
         onTap={onTap}
         onPanStart={onPanStart}
         onPanEnd={onPanEnd}

--- a/src/components/gallery/GalleryGestureHandler.tsx
+++ b/src/components/gallery/GalleryGestureHandler.tsx
@@ -14,7 +14,6 @@ import { scheduleOnRN } from 'react-native-worklets';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 import { useVector } from '../../commons/hooks/useVector';
-import { snapPoint } from '../../commons/utils/snapPoint';
 import { getVisibleRect } from '../../commons/utils/getVisibleRect';
 import { usePinchCommons } from '../../commons/hooks/usePinchCommons';
 import { useDoubleTapCommons } from '../../commons/hooks/useDoubleTapCommons';
@@ -48,6 +47,10 @@ type GalleryGestureHandlerProps = {
   pinchMode: PinchMode;
   longPressDuration: number;
   snapTimingConfig: TimingConfig;
+  snapThreshold: number;
+  swipeTimeThreshold: number;
+  swipeVelocityThreshold: number;
+  swipeDistanceThreshold: number;
   onTap?: GalleryProps['onTap'];
   onPanStart?: GalleryProps['onPanStart'];
   onPanEnd?: GalleryProps['onPanEnd'];
@@ -81,6 +84,10 @@ const GalleryGestureHandler = ({
   pinchMode,
   longPressDuration,
   snapTimingConfig,
+  snapThreshold,
+  swipeTimeThreshold,
+  swipeVelocityThreshold,
+  swipeDistanceThreshold,
   onTap,
   onPanStart,
   onPanEnd,
@@ -170,8 +177,15 @@ const GalleryGestureHandler = ({
       gap,
     });
 
-    // Gesture velocity can be used as a second parameter but 0 is fine
-    const toScroll = snapPoint(scroll.value, 0, [prev, current, next]);
+    const distance = scroll.value - current;
+    const threshold = (itemSize.value + gap) * clamp(snapThreshold, 0, 1);
+
+    let toScroll = current;
+    if (distance < 0 && Math.abs(distance) >= threshold) {
+      toScroll = prev;
+    } else if (distance > 0 && distance >= threshold) {
+      toScroll = next;
+    }
 
     scroll.value = withTiming(toScroll, snapTimingConfig, (finished) => {
       if (!finished) return;
@@ -373,6 +387,9 @@ const GalleryGestureHandler = ({
       const direction = getSwipeDirection(e, {
         boundaries: bounds,
         time: time.value,
+        timeThreshold: swipeTimeThreshold,
+        velocityThreshold: swipeVelocityThreshold,
+        distanceThreshold: swipeDistanceThreshold,
         position: { x: position.x.value, y: position.y.value },
         translate: {
           x: isPullingVertical.value ? 100 : translate.x.value,
@@ -537,6 +554,10 @@ export default React.memo(GalleryGestureHandler, (prev, next) => {
     prev.onVerticalPull === next.onVerticalPull &&
     prev.onDoubleTapStart === next.onDoubleTapStart &&
     prev.onDoubleTapEnd === next.onDoubleTapEnd &&
+    prev.snapThreshold === next.snapThreshold &&
+    prev.swipeTimeThreshold === next.swipeTimeThreshold &&
+    prev.swipeVelocityThreshold === next.swipeVelocityThreshold &&
+    prev.swipeDistanceThreshold === next.swipeDistanceThreshold &&
     prev.length === next.length &&
     prev.vertical === next.vertical &&
     prev.tapOnEdgeToItem === next.tapOnEdgeToItem &&

--- a/src/components/gallery/types.ts
+++ b/src/components/gallery/types.ts
@@ -53,6 +53,27 @@ export type GalleryProps<T = unknown> = {
   pinchMode: PinchMode;
   longPressDuration: number;
   snapTimingConfig: TimingConfig;
+  /**
+   * Fraction of an item that must be dragged before changing pages.
+   * Values are clamped between 0 and 1.
+   * @default 0.5
+   */
+  snapThreshold: number;
+  /**
+   * Maximum pan duration in milliseconds that can be recognized as a swipe.
+   * @default 175
+   */
+  swipeTimeThreshold: number;
+  /**
+   * Minimum pan velocity in points per second that triggers a page swipe.
+   * @default 500
+   */
+  swipeVelocityThreshold: number;
+  /**
+   * Minimum pan distance in points required before a swipe can change pages.
+   * @default 20
+   */
+  swipeDistanceThreshold: number;
   customTransition: GalleryTransitionCallback;
   onTap: (e: TapGestureEvent, index: number) => void;
   onLongPress: (e: LongPressEvent, index: number) => void;


### PR DESCRIPTION
## Summary

- add `snapThreshold` to configure the dragged page fraction required for a page change (default: `0.5`)
- expose every existing fast-swipe decision threshold:
  - `swipeTimeThreshold` (default: `175` ms)
  - `swipeVelocityThreshold` (default: `500` points/s)
  - `swipeDistanceThreshold` (default: `20` points)
- document the API and demonstrate `snapThreshold` in the example
- add coverage for legacy defaults, custom thresholds, and horizontal/vertical galleries

## Problem

Vertical, TikTok-style galleries often need to change page after a drag shorter than roughly 50% of the viewport. Slow pans currently use nearest-point snapping with velocity forced to zero, so consumers cannot tune the page-change decision independently from animation timing.

## Solution

`Gallery` now accepts an optional `snapThreshold`, expressed as a fraction of the distance between pages and clamped between `0` and `1`. For example, `snapThreshold={0.2}` changes a vertical page after roughly 20% of the page distance.

The existing swipe classifier's time, velocity, and distance constants are also configurable through optional Gallery props. Their current values remain the defaults, so consumers that omit the new props keep the existing behavior and feel.

```tsx
<Gallery
  data={items}
  renderItem={renderItem}
  vertical={true}
  snapThreshold={0.2}
  swipeTimeThreshold={175}
  swipeVelocityThreshold={500}
  swipeDistanceThreshold={20}
/>
```

If a different prop naming convention is preferred, I am happy to adjust it; the implementation is intentionally kept focused and usable as-is.

## Related work

#123, #106, and #113 concern snap animation duration/easing. This PR changes only the decision thresholds that determine whether the Gallery stays on the current page or moves to an adjacent page.

## Consumer context

Our Inksquad consumer wraps `Gallery` in a vertical image gallery and plans to use `snapThreshold={0.25}` after this lands. No consumer application changes are included in this upstream PR.

## Testing

Branched from the latest `main` at package version `5.1.0` (`9a09e80`).

- `yarn prepare` — passes (module and TypeScript builds)
- `yarn docs docs:build` — passes
- ESLint on all feature files — passes
- focused `getSwipeDirection` tests — 2 tests pass with a minimal compatible Jest config
- full `yarn test` cannot start because current upstream `main` mixes Jest 30 runtime with React Native's Jest 29 environment (`clearMocksOnScope`); the same failure is visible in [the latest upstream main CI run](https://github.com/Glazzes/react-native-zoom-toolkit/actions/runs/30105400164)
- full `yarn typecheck` and `yarn lint` also retain existing baseline failures in unrelated example/test files; no drive-by fixes are included

## Screenshots / GIF

Not included because this changes gesture decision behavior rather than visual layout or animation timing.

## Checklist

- [x] Props added to `Gallery` with JSDoc and TypeScript types
- [x] Existing `0.5 / 175 / 500 / 20` behavior retained as defaults
- [x] Vertical `snapThreshold={0.2}` case covered
- [x] Horizontal threshold behavior covered
- [x] Pinch zoom and zoomed-pan paths left unchanged
- [x] Documentation and example updated
